### PR TITLE
Deprecate Noto Sans Leke & Noto Sans Shuishu, unavailable Google fonts

### DIFF
--- a/basefiles/notosansleke_base.json
+++ b/basefiles/notosansleke_base.json
@@ -5,6 +5,6 @@
     "familyid": "notosansleke",
     "license": "OFL",
     "source": "Google",
-    "status": "current"
+    "status": "deprecated"
 }
 }

--- a/basefiles/notosansshuishu_base.json
+++ b/basefiles/notosansshuishu_base.json
@@ -5,6 +5,6 @@
     "familyid": "notosansshuishu",
     "license": "OFL",
     "source": "Google",
-    "status": "current"
+    "status": "deprecated"
 }
 }

--- a/families.json
+++ b/families.json
@@ -4426,7 +4426,7 @@
     "familyid": "notosansleke",
     "license": "OFL",
     "source": "Google",
-    "status": "current"
+    "status": "deprecated"
 },
 "notosanslepcha": {
     "defaults": {
@@ -5449,7 +5449,7 @@
     "familyid": "notosansshuishu",
     "license": "OFL",
     "source": "Google",
-    "status": "current"
+    "status": "deprecated"
 },
 "notosanssiddham": {
     "defaults": {


### PR DESCRIPTION
Google Font searches for "leke", "shuishu", "shui", and "sui" have no results.

I can find no reliable fallback font for [Leke](https://scriptsource.org/cms/scripts/page.php?item_id=script_detail&key=Leke); it was proposed for Unicode, but has yet to be added.

Likewise [Shuishu ](https://scriptsource.org/cms/scripts/page.php?item_id=script_detail&key=Shui) is not yet in Unicode. There are [BabelStone fonts](https://www.babelstone.co.uk/Fonts/Shuishu.html) for it, which use the Unicode Private Use Area (PUA).