### PR TITLE
Deprecate KyebogyiSIL

### DIFF
--- a/basefiles/kyebogyisil_base.json
+++ b/basefiles/kyebogyisil_base.json
@@ -1,18 +1,14 @@
 {
 "kyebogyisil": {
-    "defaults": {
-        "ttf": "kyebogyisil.ttf"
-    },
     "distributable": true,
+    "fallback": "kayphodu",
     "family": "Kyebogyi SIL",
     "familyid": "kyebogyisil",
-    "files": {
-        "kyebogyisil.ttf": { "axes": { "ital": 0, "wght": 400.0 }, "packagepath": "kyebogyisil.ttf", "url": "https://github.com/silnrsi/font-kyebogyi/raw/master/srcs/Kyebogyi_SIL.ttf" }
-    },
     "license": "OFL",
     "packageurl": "https://github.com/silnrsi/font-kyebogyi/raw/master/srcs/Kyebogyi_SIL.ttf",
     "siteurl": "https://github.com/silnrsi/font-kyebogyi",
     "source": "SIL",
+    "status": "deprecated",
     "version": "1.000"
 }
 }

--- a/basefiles/kyebogyisil_base.json
+++ b/basefiles/kyebogyisil_base.json
@@ -7,10 +7,10 @@
     "family": "Kyebogyi SIL",
     "familyid": "kyebogyisil",
     "files": {
-        "kyebogyisil.ttf": { "axes": { "ital": 0, "wght": 400.0 }, "packagepath": "kyebogyisil.ttf" }
+        "kyebogyisil.ttf": { "axes": { "ital": 0, "wght": 400.0 }, "packagepath": "kyebogyisil.ttf", "url": "https://github.com/silnrsi/font-kyebogyi/raw/master/srcs/Kyebogyi_SIL.ttf" }
     },
     "license": "OFL",
-    "packageurl": "https://github.com/silnrsi/font-kyebogyi/blob/master/srcs/Kyebogyi_SIL.ttf?raw=true",
+    "packageurl": "https://github.com/silnrsi/font-kyebogyi/raw/master/srcs/Kyebogyi_SIL.ttf",
     "siteurl": "https://github.com/silnrsi/font-kyebogyi",
     "source": "SIL",
     "version": "1.000"

--- a/families.json
+++ b/families.json
@@ -2476,10 +2476,10 @@
     "family": "Kyebogyi SIL",
     "familyid": "kyebogyisil",
     "files": {
-        "kyebogyisil.ttf": { "axes": { "ital": 0, "wght": 400.0 }, "packagepath": "kyebogyisil.ttf", "zippath": "kyebogyisil.ttf" }
+        "kyebogyisil.ttf": { "axes": { "ital": 0, "wght": 400.0 }, "packagepath": "kyebogyisil.ttf", "url": "https://github.com/silnrsi/font-kyebogyi/raw/master/srcs/Kyebogyi_SIL.ttf", "zippath": "kyebogyisil.ttf" }
     },
     "license": "OFL",
-    "packageurl": "https://github.com/silnrsi/font-kyebogyi/blob/master/srcs/Kyebogyi_SIL.ttf?raw=true",
+    "packageurl": "https://github.com/silnrsi/font-kyebogyi/raw/master/srcs/Kyebogyi_SIL.ttf",
     "siteurl": "https://github.com/silnrsi/font-kyebogyi",
     "source": "SIL",
     "version": "1.000"

--- a/families.json
+++ b/families.json
@@ -2469,19 +2469,15 @@
     "ziproot": ""
 },
 "kyebogyisil": {
-    "defaults": {
-        "ttf": "kyebogyisil.ttf"
-    },
     "distributable": true,
+    "fallback": "kayphodu",
     "family": "Kyebogyi SIL",
     "familyid": "kyebogyisil",
-    "files": {
-        "kyebogyisil.ttf": { "axes": { "ital": 0, "wght": 400.0 }, "packagepath": "kyebogyisil.ttf", "url": "https://github.com/silnrsi/font-kyebogyi/raw/master/srcs/Kyebogyi_SIL.ttf", "zippath": "kyebogyisil.ttf" }
-    },
     "license": "OFL",
     "packageurl": "https://github.com/silnrsi/font-kyebogyi/raw/master/srcs/Kyebogyi_SIL.ttf",
     "siteurl": "https://github.com/silnrsi/font-kyebogyi",
     "source": "SIL",
+    "status": "deprecated",
     "version": "1.000"
 },
 "lateef": {


### PR DESCRIPTION
Also, prefer `**/raw/**/*.ttf` to `**/blob/**/*.ttf?raw=true` to match the other basefiles.