### PR TITLE
Fix jq examples

### DIFF
--- a/contrib/jq-queries.txt
+++ b/contrib/jq-queries.txt
@@ -1,4 +1,3 @@
-
 jq is a json processor (https://jqlang.github.io/jq/)
 Here are some possibly useful queries to run against families.json:
 
@@ -15,11 +14,7 @@ Find all fonts which status is not current:
 jq 'map({family: .family, status: .status | select( . != "current" ), source: .source})' families.json 
 
 Find all fonts which have some sort of fallback:
-jq 'map({family: .family, status: .status, fallback: .fallback})' families.json
-
-
+jq 'map({family: .family, status: .status, fallback: .fallback | select ( . )})' families.json
 
 Get some numbers on the licensing landscape (using the miller filter from https://github.com/johnkerl/miller):
-jq 'map({family: .family, license: .license, source: .source})' families.json | mlr --ijson --ocsv uniq -c -g license then sort -r count
-
-
+jq 'map({family: .family, license: .license, source: .source})' families.json | mlr --ijson --ocsv uniq -c -g license then sort -f license then sort -nr count


### PR DESCRIPTION
The query `jq 'map({family: .family, status: .status, fallback: .fallback})' families.json` was missing a filter to avoid `fallback: null`, so added a filter: `fallback: .fallback | select ( . )})`.

The query `jq 'map({family: .family, license: .license, source: .source})' families.json | mlr --ijson --ocsv uniq -c -g license then sort -r count` is using `-r` which is descending lexical sort (https://miller.readthedocs.io/en/6.12.0/reference-verbs/#sort). Replaced with `sort -nr count` for descending numerical sort. Also preceded with `sort -f license` to lexically sort licenses with the same number of hits.

