### PR TITLE
Fill in Noto Serif NP Hmong

### DIFF
--- a/basefiles/notoserifnphmong_base.json
+++ b/basefiles/notoserifnphmong_base.json
@@ -4,7 +4,7 @@
         "ttf": "NotoSerifNPHmong-Regular.ttf"
     },
     "distributable": true,
-    "family": "Noto Serif Nyiakeng Puachue Hmong",
+    "family": "Noto Serif NP Hmong",
     "familyid": "notoserifnphmong",
     "files": {
         "NotoSerifNPHmong-Bold.ttf": { "axes": { "wght": 700.0 }, "packagepath": "full/ttf/NotoSerifNPHmong-Bold.ttf", "url": "https://github.com/notofonts/notofonts.github.io/raw/main/fonts/NotoSerifNPHmong/full/ttf/NotoSerifNPHmong-Bold.ttf" },

--- a/basefiles/notoserifnphmong_base.json
+++ b/basefiles/notoserifnphmong_base.json
@@ -1,10 +1,23 @@
 {
 "notoserifnphmong": {
+    "defaults": {
+        "ttf": "NotoSerifNPHmong-Regular.ttf"
+    },
     "distributable": true,
-    "family": "Noto Serif NP Hmong",
+    "family": "Noto Serif Nyiakeng Puachue Hmong",
     "familyid": "notoserifnphmong",
+    "files": {
+        "NotoSerifNPHmong-Bold.ttf": { "axes": { "wght": 700.0 }, "packagepath": "full/ttf/NotoSerifNPHmong-Bold.ttf", "url": "https://github.com/notofonts/notofonts.github.io/raw/main/fonts/NotoSerifNPHmong/full/ttf/NotoSerifNPHmong-Bold.ttf" },
+        "NotoSerifNPHmong-Medium.ttf": { "axes": { "wght": 500.0 }, "packagepath": "full/ttf/NotoSerifNPHmong-Medium.ttf", "url": "https://github.com/notofonts/notofonts.github.io/raw/main/fonts/NotoSerifNPHmong/full/ttf/NotoSerifNPHmong-Medium.ttf" },
+        "NotoSerifNPHmong-Regular.ttf": { "axes": { "wght": 400.0 }, "packagepath": "full/ttf/NotoSerifNPHmong-Regular.ttf", "url": "https://github.com/notofonts/notofonts.github.io/raw/main/fonts/NotoSerifNPHmong/full/ttf/NotoSerifNPHmong-Regular.ttf" },
+        "NotoSerifNPHmong-SemiBold.ttf": { "axes": { "wght": 600.0 }, "packagepath": "full/ttf/NotoSerifNPHmong-SemiBold.ttf", "url": "https://github.com/notofonts/notofonts.github.io/raw/main/fonts/NotoSerifNPHmong/full/ttf/NotoSerifNPHmong-SemiBold.ttf" }
+    },
     "license": "OFL",
+    "packageurl": "https://github.com/notofonts/nyiakeng-puachue-hmong/releases/download/NotoSerifNPHmong-v1.001/NotoSerifNPHmong-v1.001.zip",
+    "siteurl": "https://github.com/notofonts/nyiakeng-puachue-hmong/releases/tag/NotoSerifNPHmong-v1.001",
     "source": "Google",
-    "status": "current"
+    "status": "current",
+    "version": "1.001",
+    "ziproot": "NotoSerifNPHmong"
 }
 }

--- a/families.json
+++ b/families.json
@@ -7177,7 +7177,7 @@
         "ttf": "NotoSerifNPHmong-Regular.ttf"
     },
     "distributable": true,
-    "family": "Noto Serif Nyiakeng Puachue Hmong",
+    "family": "Noto Serif NP Hmong",
     "familyid": "notoserifnphmong",
     "files": {
         "NotoSerifNPHmong-Bold.ttf": { "axes": { "wght": 700.0 }, "packagepath": "full/ttf/NotoSerifNPHmong-Bold.ttf", "url": "https://github.com/notofonts/notofonts.github.io/raw/main/fonts/NotoSerifNPHmong/full/ttf/NotoSerifNPHmong-Bold.ttf", "zippath": "NotoSerifNPHmong/full/ttf/NotoSerifNPHmong-Bold.ttf" },

--- a/families.json
+++ b/families.json
@@ -7173,12 +7173,25 @@
     "ziproot": "NotoSerifMyanmar"
 },
 "notoserifnphmong": {
+    "defaults": {
+        "ttf": "NotoSerifNPHmong-Regular.ttf"
+    },
     "distributable": true,
-    "family": "Noto Serif NP Hmong",
+    "family": "Noto Serif Nyiakeng Puachue Hmong",
     "familyid": "notoserifnphmong",
+    "files": {
+        "NotoSerifNPHmong-Bold.ttf": { "axes": { "wght": 700.0 }, "packagepath": "full/ttf/NotoSerifNPHmong-Bold.ttf", "url": "https://github.com/notofonts/notofonts.github.io/raw/main/fonts/NotoSerifNPHmong/full/ttf/NotoSerifNPHmong-Bold.ttf", "zippath": "NotoSerifNPHmong/full/ttf/NotoSerifNPHmong-Bold.ttf" },
+        "NotoSerifNPHmong-Medium.ttf": { "axes": { "wght": 500.0 }, "packagepath": "full/ttf/NotoSerifNPHmong-Medium.ttf", "url": "https://github.com/notofonts/notofonts.github.io/raw/main/fonts/NotoSerifNPHmong/full/ttf/NotoSerifNPHmong-Medium.ttf", "zippath": "NotoSerifNPHmong/full/ttf/NotoSerifNPHmong-Medium.ttf" },
+        "NotoSerifNPHmong-Regular.ttf": { "axes": { "wght": 400.0 }, "packagepath": "full/ttf/NotoSerifNPHmong-Regular.ttf", "url": "https://github.com/notofonts/notofonts.github.io/raw/main/fonts/NotoSerifNPHmong/full/ttf/NotoSerifNPHmong-Regular.ttf", "zippath": "NotoSerifNPHmong/full/ttf/NotoSerifNPHmong-Regular.ttf" },
+        "NotoSerifNPHmong-SemiBold.ttf": { "axes": { "wght": 600.0 }, "packagepath": "full/ttf/NotoSerifNPHmong-SemiBold.ttf", "url": "https://github.com/notofonts/notofonts.github.io/raw/main/fonts/NotoSerifNPHmong/full/ttf/NotoSerifNPHmong-SemiBold.ttf", "zippath": "NotoSerifNPHmong/full/ttf/NotoSerifNPHmong-SemiBold.ttf" }
+    },
     "license": "OFL",
+    "packageurl": "https://github.com/notofonts/nyiakeng-puachue-hmong/releases/download/NotoSerifNPHmong-v1.001/NotoSerifNPHmong-v1.001.zip",
+    "siteurl": "https://github.com/notofonts/nyiakeng-puachue-hmong/releases/tag/NotoSerifNPHmong-v1.001",
     "source": "Google",
-    "status": "current"
+    "status": "current",
+    "version": "1.001",
+    "ziproot": "NotoSerifNPHmong"
 },
 "notoserifolduyghur": {
     "defaults": {


### PR DESCRIPTION
Fills in `defaults`, `files`, `packageurl`, `siteurl`, `version` and `ziproot`.

~Also, changes `family` from "Noto Serif NP Hmong" to "Noto Serif Nyiakeng Puachue Hmong" to match the full name in https://fonts.google.com/noto/specimen/Noto+Serif+NP+Hmong.~ Retracted `family` change because the ttf installs "Noto Serif NP Hmong".